### PR TITLE
Fix missing radial dependencies

### DIFF
--- a/apps/waitlist/package.json
+++ b/apps/waitlist/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@workspace/ui": "workspace:*",
+    "@radix-ui/react-compose-refs": "^1.1.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "scheduler": "^0.26.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,11 +13,13 @@
   },
   "dependencies": {
     "@workspace/ui": "workspace:*",
+    "@radix-ui/react-compose-refs": "^1.1.2",
     "lucide-react": "^0.475.0",
     "next": "^15.2.3",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "scheduler": "^0.26.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,12 +8,14 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-compose-refs": "^1.1.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "scheduler": "^0.26.0",
     "tailwind-merge": "^3.0.1",
     "tw-animate-css": "^1.2.4",
     "zod": "^3.24.2"

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -1,9 +1,8 @@
 @import "tailwindcss";
+@import "tw-animate-css";
 @source "../../../apps/**/*.{ts,tsx}";
 @source "../../../components/**/*.{ts,tsx}";
 @source "../**/*.{ts,tsx}";
-
-@import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/waitlist:
     dependencies:
+      '@radix-ui/react-compose-refs':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react@19.1.7)(react@19.1.0)
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -35,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      scheduler:
+        specifier: ^0.26.0
+        version: 0.26.0
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -66,6 +72,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@radix-ui/react-compose-refs':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react@19.1.7)(react@19.1.0)
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -84,6 +93,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      scheduler:
+        specifier: ^0.26.0
+        version: 0.26.0
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -150,6 +162,9 @@ importers:
 
   packages/ui:
     dependencies:
+      '@radix-ui/react-compose-refs':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react@19.1.7)(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.1.2
         version: 1.2.3(@types/react@19.1.7)(react@19.1.0)
@@ -171,6 +186,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      scheduler:
+        specifier: ^0.26.0
+        version: 0.26.0
       tailwind-merge:
         specifier: ^3.0.1
         version: 3.3.0


### PR DESCRIPTION
## Summary
- add missing dependencies for Radix and React scheduler
- reorder CSS imports to avoid build warnings

## Testing
- `pnpm run build` in `apps/waitlist`
- `pnpm run build` in `apps/web` *(fails: Failed to fetch Geist fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684800233e508326872f5a60085f308e